### PR TITLE
Avoid panic on invalid processor family

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,9 @@ pub enum MalformedStructureError {
         _0, _1, _2, _3
     )]
     InvalidFormattedSectionLength(InfoType, u16, &'static str, u8),
+    /// The SMBIOS structure contains an invalid processor family
+    #[fail(display = "Invalid processor family")]
+    InvalidProcessorFamily
 }
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ pub struct RawStructure<'buffer> {
 
 /// General trait for slice -> unsigned conversion
 pub trait TryFromBytes<'a, T>: Sized {
-    fn try_from_bytes(&'a [u8]) -> Result<Self, TryFromSliceError>;
+    fn try_from_bytes(_: &'a [u8]) -> Result<Self, TryFromSliceError>;
 }
 
 impl<'a> TryFromBytes<'a, u8> for u8 {


### PR DESCRIPTION
We are seeing some workflows that reaches an `unreachable!` block in our production deployment. 
This happens because there is some BIOS information that is not according to spec in a customer machine and when we try to use `dmidecode` to decode it, it blows up (by going into the `unreachable!` block) rather than return an error for us to handle appropriately. 

In the spirit of errors over panics for invalid input we should use `TryFrom` rather than the infallible `From` for the conversion from bytes to the processor family enum. 