### PR TITLE
Fix InfoType error type reported on SystemConfigurationOptions

### DIFF
--- a/src/structures/012_system_configuration_options.rs
+++ b/src/structures/012_system_configuration_options.rs
@@ -30,7 +30,7 @@ impl<'a> SystemConfigurationOptions<'a> {
         let count: u8 = structure.get::<u8>(0x04)?;
         let strings = structure.strings();
         if count as usize != strings.count() {
-            Err(InvalidStringIndex(InfoType::OemStrings, structure.handle, count))
+            Err(InvalidStringIndex(InfoType::SystemConfigurationOptions, structure.handle, count))
         } else {
             Ok(SystemConfigurationOptions {
                 handle: structure.handle,


### PR DESCRIPTION
Noticed while investigating `SystemConfigurationOptions` parsing issues,
this change corrects the `InfoType` reported in the error pointing it to
`SystemConfigurationOptions` instead of `OemStrings`.

Here's the misleading error message that pointed out to `OemStrings`.

```
Structure OemStrings with handle 37 has invalid string index 8
```