### PR TITLE
Change MemoryDevice length enforcement for smbios 3.2 to at least 40 bytes

### DIFF
--- a/src/structures/012_system_configuration_options.rs
+++ b/src/structures/012_system_configuration_options.rs
@@ -30,7 +30,7 @@ impl<'a> SystemConfigurationOptions<'a> {
         let count: u8 = structure.get::<u8>(0x04)?;
         let strings = structure.strings();
         if count as usize != strings.count() {
-            Err(InvalidStringIndex(InfoType::OemStrings, structure.handle, count))
+            Err(InvalidStringIndex(InfoType::SystemConfigurationOptions, structure.handle, count))
         } else {
             Ok(SystemConfigurationOptions {
                 handle: structure.handle,


### PR DESCRIPTION
The current MemoryDevice length enforcement set at 0x54 (84 bytes) causes systems with smbios 3.2 with 0x28 (40 bytes) length to fail with `InvalidFormattedSectionLength` error.

This change adjust the length enforcement to at least 40 bytes, instead of the previous hard limit set at 84 bytes.

Fix issue #17.