### PR TITLE
Change MemoryDevice length enforcement for smbios 2.8 to at least 34 bytes

### DIFF
--- a/src/structures/012_system_configuration_options.rs
+++ b/src/structures/012_system_configuration_options.rs
@@ -30,7 +30,7 @@ impl<'a> SystemConfigurationOptions<'a> {
         let count: u8 = structure.get::<u8>(0x04)?;
         let strings = structure.strings();
         if count as usize != strings.count() {
-            Err(InvalidStringIndex(InfoType::OemStrings, structure.handle, count))
+            Err(InvalidStringIndex(InfoType::SystemConfigurationOptions, structure.handle, count))
         } else {
             Ok(SystemConfigurationOptions {
                 handle: structure.handle,

--- a/src/structures/017_memory_device.rs
+++ b/src/structures/017_memory_device.rs
@@ -212,6 +212,8 @@ pub enum Type {
     LpDdr,
     LpDdr2,
     LpDdr3,
+    LpDdr4,
+    LogicalNonVolatileDevice,
     Undefined(u8),
 }
 
@@ -253,6 +255,8 @@ impl From<u8> for Type {
             27 => Type::LpDdr,
             28 => Type::LpDdr2,
             29 => Type::LpDdr3,
+            30 => Type::LpDdr4,
+            31 => Type::LogicalNonVolatileDevice,
             t => Type::Undefined(t),
         }
     }


### PR DESCRIPTION
Fixes issue #21 