### PR TITLE
do not enforce string count for OemStrings

### DIFF
--- a/src/structures/011_oem_strings.rs
+++ b/src/structures/011_oem_strings.rs
@@ -5,11 +5,7 @@
 
 
 use crate::{
-    InfoType,
-    MalformedStructureError::{
-        self,
-        InvalidStringIndex,
-    },
+    MalformedStructureError,
     RawStructure,
     StructureStrings,
 };
@@ -26,16 +22,11 @@ pub struct OemStrings<'a> {
 
 impl<'a> OemStrings<'a> {
     pub(crate) fn try_from(structure: RawStructure<'a>) -> Result<Self, MalformedStructureError> {
-        let count: u8 = structure.get::<u8>(0x04)?;
         let strings = structure.strings();
-        if count as usize != strings.count() {
-            Err(InvalidStringIndex(InfoType::OemStrings, structure.handle, count))
-        } else {
-            Ok(OemStrings {
-                handle: structure.handle,
-                strings,
-            })
-        }
+        Ok(OemStrings {
+            handle: structure.handle,
+            strings,
+        })
     }
 }
 


### PR DESCRIPTION
Although there is an explicit count for the number of OemStrings,
firmware manufacturers do not necessarily keep it up to date with the
actual number of strings. Any code that is using the OemStrings
structure (with the strings iterator) will be able to walk all of the
strings that are present if we do not enforce checking the count. Fixes
