### PR TITLE
Make enclosure + memory device parsing be best effort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Decode SMBIOS/DMI information into accessible data structures"
 documentation = "https://docs.rs/dmidecode/"
 homepage = "https://github.com/jcreekmore/dmidecode.git"
 license = "MIT"
+rust-version = "1.62"
 
 [dependencies]
 aho-corasick = "0.6.4"

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -275,7 +275,7 @@ impl<'a, T> Significants<'a, T> {
 impl<'a, T: Into<u128> + Copy> Iterator for Significants<'a, T> {
     type Item = Flag<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(f) = self.0.next() {
+        for f in self.0.by_ref() {
             if matches!(f.type_, FlagType::Reserved(_)) || !f.is_set {
                 continue;
             }
@@ -298,11 +298,11 @@ impl<'a, T: Into<u128> + Copy + fmt::Debug> Iterator for Reserved<'a, T> {
     type Item = ReservedRange<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         let mut end = 0;
-        while let Some(Flag {
+        for Flag {
             position: Position(p),
             type_,
             ..
-        }) = self.iter.next()
+        } in self.iter.by_ref()
         {
             match (type_, self.desc) {
                 (FlagType::Reserved(s), Some(desc)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,8 +443,8 @@ impl<'buffer> Iterator for Structures<'buffer> {
                 // future iterations. This will avoid any nfinite
                 // iterations when skipping errors
                 self.smbios_len = self.idx;
-                return Some(Err(e))
-            },
+                return Some(Err(e));
+            }
         };
 
         /*

--- a/src/structures/000_bios.rs
+++ b/src/structures/000_bios.rs
@@ -364,14 +364,14 @@ mod tests {
     use crate::bitfield::Position;
 
     const PRIMES: &[usize] = &[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61];
-    const DMIDECODE_BIN: &'static [u8] = include_bytes!("../../tests/data/dmi.0.bin");
+    const DMIDECODE_BIN: &[u8] = include_bytes!("../../tests/data/dmi.0.bin");
     lazy_static! {
         static ref ENTRY_POINT: crate::EntryPoint = crate::EntryPoint::search(DMIDECODE_BIN).unwrap();
     }
 
     #[test]
     fn characteristics() {
-        let sample = PRIMES.iter().cloned().collect::<Vec<_>>();
+        let sample = PRIMES.to_vec();
         let qword = sample.iter().map(|&p| Position(p)).collect();
         let result = Characteristics(qword)
             .iter()

--- a/src/structures/003_enclosure.rs
+++ b/src/structures/003_enclosure.rs
@@ -736,7 +736,7 @@ mod tests {
             data: &[1, 1, 0, 0, 0, 3, 3, 3, 2, 0, 0, 0, 0, 0, 0, 0],
             strings: &[71, 111, 111, 103, 108, 101, 0, 0],
         })
-            .expect("failed to create enclosure");
+        .expect("failed to create enclosure");
 
         assert_eq!(
             enclosure,

--- a/src/structures/003_enclosure.rs
+++ b/src/structures/003_enclosure.rs
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     fn dmi_bin() {
         use super::*;
-        const DMIDECODE_BIN: &'static [u8] = include_bytes!("../../tests/data/dmi.0.bin");
+        const DMIDECODE_BIN: &[u8] = include_bytes!("../../tests/data/dmi.0.bin");
         let entry_point = crate::EntryPoint::search(DMIDECODE_BIN).unwrap();
         let enc = entry_point
             .structures(&DMIDECODE_BIN[(entry_point.smbios_address() as usize)..])
@@ -764,7 +764,7 @@ mod tests {
         assert_eq!(
             enc.contained_elements
                 .clone()
-                .and_then(|mut ce| ce.nth(0).map(|s| format!("{}", s))),
+                .and_then(|mut ce| ce.next().map(|s| format!("{}", s))),
             Some("Structure type: Memory Device (1-2)".into()),
             "Number Of Power Cords"
         );
@@ -776,7 +776,7 @@ mod tests {
             "Number Of Power Cords"
         );
         assert_eq!(
-            enc.sku_number.map(|v| format!("{}", v)),
+            enc.sku_number.map(|v| v.to_string()),
             Some("SKU Number".into()),
             "SKU Number"
         );

--- a/src/structures/008_port_connector.rs
+++ b/src/structures/008_port_connector.rs
@@ -413,7 +413,7 @@ mod test {
     fn dmi_bin() {
         use super::*;
         use crate::{EntryPoint, Structure};
-        const DMIDECODE_BIN: &'static [u8] = include_bytes!("../../tests/data/dmi.0.bin");
+        const DMIDECODE_BIN: &[u8] = include_bytes!("../../tests/data/dmi.0.bin");
         let entry_point = EntryPoint::search(DMIDECODE_BIN).unwrap();
         let connectors = entry_point
             .structures(&DMIDECODE_BIN[(entry_point.smbios_address() as usize)..])

--- a/src/structures/011_oem_strings.rs
+++ b/src/structures/011_oem_strings.rs
@@ -61,7 +61,7 @@ mod tests {
     fn dmi_bin() {
         use super::*;
         use crate::{EntryPoint, Structure, StructureStrings};
-        const DMIDECODE_BIN: &'static [u8] = include_bytes!("../../tests/data/dmi.0.bin");
+        const DMIDECODE_BIN: &[u8] = include_bytes!("../../tests/data/dmi.0.bin");
         let entry_point = EntryPoint::search(DMIDECODE_BIN).unwrap();
         let oem_strings = entry_point
             .structures(&DMIDECODE_BIN[(entry_point.smbios_address() as usize)..])

--- a/src/structures/012_system_configuration_options.rs
+++ b/src/structures/012_system_configuration_options.rs
@@ -75,7 +75,7 @@ mod tests {
     fn dmi_bin() {
         use super::*;
         use crate::{EntryPoint, Structure, StructureStrings};
-        const DMIDECODE_BIN: &'static [u8] = include_bytes!("../../tests/data/dmi.0.bin");
+        const DMIDECODE_BIN: &[u8] = include_bytes!("../../tests/data/dmi.0.bin");
         let entry_point = EntryPoint::search(DMIDECODE_BIN).unwrap();
         let oem_strings = entry_point
             .structures(&DMIDECODE_BIN[(entry_point.smbios_address() as usize)..])

--- a/src/structures/013_bios_language.rs
+++ b/src/structures/013_bios_language.rs
@@ -111,7 +111,7 @@ mod tests {
 
     use super::*;
 
-    const DMIDECODE_BIN: &'static [u8] = include_bytes!("../../tests/data/dmi.0.bin");
+    const DMIDECODE_BIN: &[u8] = include_bytes!("../../tests/data/dmi.0.bin");
     lazy_static! {
         static ref ENTRY_POINT: crate::EntryPoint = crate::EntryPoint::search(DMIDECODE_BIN).unwrap();
     }

--- a/src/structures/014_group_associations.rs
+++ b/src/structures/014_group_associations.rs
@@ -71,7 +71,7 @@ impl<'a> Iterator for GroupItems<'a> {
         let end = start + 3;
         let slice = self.data.get(start..end)?;
         self.index = end;
-        let type_ = *slice.get(0)?;
+        let type_ = *slice.first()?;
         let handle = slice.get(1..).and_then(|s| u16::try_from_bytes(s).ok())?;
         Some(GroupItem { type_, handle })
     }

--- a/src/structures/016_physical_memory_array.rs
+++ b/src/structures/016_physical_memory_array.rs
@@ -221,13 +221,13 @@ impl PhysicalMemoryArray {
             mem_pointer += 1;
             pma.memory_error_correction = MemoryArrayErrorCorrectionTypes::from(structure.data[mem_pointer]);
             mem_pointer += 1;
-            pma.maximum_capacity = get_optional_dword(&mut mem_pointer, &structure.data, 0x80000000)?;
-            pma.memory_error_information_handle = get_optional_word(&mut mem_pointer, &structure.data, 0xFFFE)?;
-            pma.number_of_memory_devices = get_word(&mut mem_pointer, &structure.data)?;
+            pma.maximum_capacity = get_optional_dword(&mut mem_pointer, structure.data, 0x80000000)?;
+            pma.memory_error_information_handle = get_optional_word(&mut mem_pointer, structure.data, 0xFFFE)?;
+            pma.number_of_memory_devices = get_word(&mut mem_pointer, structure.data)?;
         }
         if structure.version > (2, 7).into() {
             pma.extended_maximum_capacity = if pma.maximum_capacity.is_none() {
-                get_optional_qword(&mut mem_pointer, &structure.data, 0)?
+                get_optional_qword(&mut mem_pointer, structure.data, 0)?
             } else {
                 None
             };
@@ -267,7 +267,7 @@ fn get_word(pointer: &mut usize, data: &[u8]) -> Result<u16, MalformedStructureE
     let word = u16::from_le_bytes(
         data[*pointer..(*pointer + 2)]
             .try_into()
-            .map_err(|e| MalformedStructureError::InvalidSlice(e))?,
+            .map_err(MalformedStructureError::InvalidSlice)?,
     );
     *pointer += 2;
     Ok(word)
@@ -277,7 +277,7 @@ fn get_dword(pointer: &mut usize, data: &[u8]) -> Result<u32, MalformedStructure
     let dword = u32::from_le_bytes(
         data[*pointer..(*pointer + 4)]
             .try_into()
-            .map_err(|e| MalformedStructureError::InvalidSlice(e))?,
+            .map_err(MalformedStructureError::InvalidSlice)?,
     );
     *pointer += 4;
     Ok(dword)
@@ -287,7 +287,7 @@ fn get_qword(pointer: &mut usize, data: &[u8]) -> Result<u64, MalformedStructure
     let qword = u64::from_le_bytes(
         data[*pointer..(*pointer + 8)]
             .try_into()
-            .map_err(|e| MalformedStructureError::InvalidSlice(e))?,
+            .map_err(MalformedStructureError::InvalidSlice)?,
     );
     *pointer += 8;
     Ok(qword)

--- a/src/structures/017_memory_device.rs
+++ b/src/structures/017_memory_device.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bad_bit_mask)]
+
 //! Memory Device (Type 17)
 //!
 //! This structure describes a single memory device that is part of a larger [Physical Memory
@@ -95,9 +97,10 @@ impl From<u8> for ErrorType {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Default)]
 pub enum FormFactor {
     Other,
+    #[default]
     Unknown,
     Simm,
     Sip,
@@ -113,12 +116,6 @@ pub enum FormFactor {
     Srimm,
     FbDimm,
     Undefined(u8),
-}
-
-impl Default for FormFactor {
-    fn default() -> Self {
-        FormFactor::Unknown
-    }
 }
 
 impl From<u8> for FormFactor {
@@ -145,9 +142,10 @@ impl From<u8> for FormFactor {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Default)]
 pub enum MemoryTechnology {
     Other,
+    #[default]
     Unknown,
     Dram,
     NvDimmN,
@@ -155,12 +153,6 @@ pub enum MemoryTechnology {
     NvDimmP,
     IntelOptane,
     Undefined(u8),
-}
-
-impl Default for MemoryTechnology {
-    fn default() -> Self {
-        MemoryTechnology::Unknown
-    }
 }
 
 impl From<u8> for MemoryTechnology {
@@ -178,9 +170,10 @@ impl From<u8> for MemoryTechnology {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Default)]
 pub enum Type {
     Other,
+    #[default]
     Unknown,
     Dram,
     Edram,
@@ -214,12 +207,6 @@ pub enum Type {
     Hbm,
     Hbm2,
     Undefined(u8),
-}
-
-impl Default for Type {
-    fn default() -> Self {
-        Type::Unknown
-    }
 }
 
 impl From<u8> for Type {

--- a/src/structures/021_built_in_pointing_device.rs
+++ b/src/structures/021_built_in_pointing_device.rs
@@ -173,8 +173,8 @@ mod tests {
             "Touch Screen",
             "Optical Sensor",
         ];
-        for n in 0..sample.len() {
-            assert_eq!(sample[n], format!("{:#}", Type::from(n as u8)));
+        for (n, &s) in sample.iter().enumerate() {
+            assert_eq!(s, format!("{:#}", Type::from(n as u8)));
         }
     }
 
@@ -193,8 +193,8 @@ mod tests {
             "Bus mouse",
             "ADB (Apple Desktop Bus)",
         ];
-        for n in 0..sample.len() {
-            assert_eq!(sample[n], format!("{:#}", Interface::from(n as u8)));
+        for (n, &s) in sample.iter().enumerate() {
+            assert_eq!(s, format!("{:#}", Interface::from(n as u8)));
         }
         let sample = &["Bus mouse DB-9", "Bus mouse micro-DIN", "USB"];
         for n in 0xA0..(0xA0 + sample.len()) {

--- a/src/structures/022_portable_battery.rs
+++ b/src/structures/022_portable_battery.rs
@@ -291,9 +291,9 @@ mod tests {
             "Zinc air",
             "Lithium Polymer",
         ];
-        for n in 0..sample.len() {
+        for (n, &s) in sample.iter().enumerate() {
             let sbds = None;
-            assert_eq!(sample[n], format!("{}", DeviceChemistry::new(n as u8, sbds)));
+            assert_eq!(s, format!("{}", DeviceChemistry::new(n as u8, sbds)));
             if n == 0x02 {
                 let sbds = Some("PbAc");
                 assert_eq!("PbAc", format!("{:#}", DeviceChemistry::new(n as u8, sbds)));


### PR DESCRIPTION
I was testing this library inside a fairly new GCP instance with a BIOS version of 3.4 but some of the fields that this library expects for those versions were missing which would make the entire parsing of the struct fail. Ideally grabbing fields should be best effort so we can get as much information as possible even if the BIOS wasn't written exactly to spec. 

The spec does *allow* for optional fields (although the tables make it ambiguous IMO): https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.0.pdf

> * Starting with version 2.3, each SMBIOS structure type has a minimum length — enabling the addition of new, but optional, fields to SMBIOS structures. In no case shall a structure’s length  result in a field being less than fully populated. For example, a Voltage Probe structure with  Length of 15h is invalid because the Nominal Value field would not be fully specified.
> * Software that interprets a structure field must verify that the structure’s length is sufficient to  encompass the optional field; if the length is insufficient, the optional field’s value is Unknown.  For example, if a Voltage Probe structure has a Length field of 14h, the probe’s Nominal Value 
is Unknown. A Voltage Probe structure with Length greater than 14h always includes a Nominal  Value field.

This PR specifically only tackles enclosure + memory device structures as those were the two that were failing in my GCP instance. Further work would need to be done in the other structures. 

I recommend going through this PR commit by commit to not confuse the initial clean-up commits from the meat of the PR:

1. Runs `cargo clippy` and fixes/adds allows where necessary
2. Sets up a MSRV in `Cargo.toml` to make it clear what version I should be making sure things still compile + run. I set the MSRV to v1.62 as the `cargo clippy` from before added some code that would only compile in v1.62+. I am not sure what the incidental MSRV was before but there didn't seem to be an intentional one. v1.62 came out over a year ago so I think that's OK.
3. Forces the `Structures` iterator to terminate after any "fatal" error. By "fatal" error I mean any error that happens prior to advancing the index, and hence would cause an infinite iteration if skipped. This will allow people to safely continue iterating even if some structures failed to be parsed. In my case I only cared about a couple of structs so I didn't care if some structs failed to parse but that was unsafe because some errors don't advance the index and would cause an infinite iteration.
4. Loosens up the restrictions in `Enclosure` to allow for fields to be missing as long as the minimum fields from v2.0 are in there
5. Loosens up the restrictions in `MemoryDevice` to allow for fields to be missing as long as the minimum fields from v2.1 (the version where this structure appeared) are in there. 