### PR TITLE
Fix no-std build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ pretty_assertions = "0.6"
 lazy_static = "1.4"
 
 [features]
-default = ["std"]
+default = []
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ license = "MIT"
 rust-version = "1.62"
 
 [dependencies]
-aho-corasick = "0.6.4"
 bitflags = "1.2"
-failure = "0.1.1"
-failure_derive = "0.1.1"
 lazy_static = "1.0.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 lazy_static = "1.4"
+
+[features]
+default = ["spin_no_std"]
+std = []
+spin_no_std = ["lazy_static/spin_no_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,11 @@ rust-version = "1.62"
 
 [dependencies]
 bitflags = "1.2"
-lazy_static = "1.0.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6"
 lazy_static = "1.4"
 
 [features]
-default = ["spin_no_std"]
+default = ["std"]
 std = []
-spin_no_std = ["lazy_static/spin_no_std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,26 +408,30 @@ pub enum Structure<'buffer> {
 
 #[derive(Debug)]
 pub enum MalformedStructureError {
-      /// The SMBIOS structure exceeds the end of the memory buffer given to the `EntryPoint::structures` method.
-      BadSize(u32, u8),
-      /// The SMBIOS structure contains an unterminated strings section.
-      UnterminatedStrings(u32),
-      /// The SMBIOS structure contains an invalid string index.
-      InvalidStringIndex(InfoType, u16, u8),
-      /// This error returned when a conversion from a slice to an array fails.
-      InvalidSlice(core::array::TryFromSliceError),
-      /// The SMBIOS structure formatted section length does not correspond to SMBIOS reference
-      /// specification
-      InvalidFormattedSectionLength(InfoType, u16, &'static str, u8),
-      /// The SMBIOS structure contains an invalid processor family
-      InvalidProcessorFamily,
+    /// The SMBIOS structure exceeds the end of the memory buffer given to the `EntryPoint::structures` method.
+    BadSize(u32, u8),
+    /// The SMBIOS structure contains an unterminated strings section.
+    UnterminatedStrings(u32),
+    /// The SMBIOS structure contains an invalid string index.
+    InvalidStringIndex(InfoType, u16, u8),
+    /// This error returned when a conversion from a slice to an array fails.
+    InvalidSlice(core::array::TryFromSliceError),
+    /// The SMBIOS structure formatted section length does not correspond to SMBIOS reference
+    /// specification
+    InvalidFormattedSectionLength(InfoType, u16, &'static str, u8),
+    /// The SMBIOS structure contains an invalid processor family
+    InvalidProcessorFamily,
 }
 
 impl fmt::Display for MalformedStructureError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MalformedStructureError::BadSize(offset, length) => {
-                write!(f, "Structure at offset {} with length {} extends beyond SMBIOS", offset, length)
+                write!(
+                    f,
+                    "Structure at offset {} with length {} extends beyond SMBIOS",
+                    offset, length
+                )
             }
             MalformedStructureError::UnterminatedStrings(offset) => {
                 write!(f, "Structure at offset {} with unterminated strings", offset)
@@ -465,7 +469,6 @@ impl std::error::Error for MalformedStructureError {
         }
     }
 }
-
 
 #[doc(hidden)]
 /// Finds the final nul nul terminator of a buffer and returns the index of the final nul

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,11 +156,10 @@ impl EntryPoint {
     /// # Example
     ///
     /// ```
-    /// # extern crate failure;
     /// # extern crate dmidecode;
-    /// # use failure::Error;
+    /// # use std::error::Error;
     /// use dmidecode::EntryPoint;
-    /// # fn try_main() -> Result<(), Error> {
+    /// # fn try_main() -> Result<(), Box<dyn Error>> {
     /// #
     /// const DMIDECODE_BIN: &'static [u8] = include_bytes!("../tests/data/dmidecode.bin");
     ///

--- a/src/structures/004_processor.rs
+++ b/src/structures/004_processor.rs
@@ -6,6 +6,9 @@
 //! IntelSX2™ processor would have a structure to describe the main CPU and a second structure to
 //! describe the 80487 co1021 processor.
 
+#[cfg(feature = "std")]
+extern crate std;
+
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -803,15 +806,24 @@ impl TryFrom<u8> for ProcessorFamily {
         ProcessorFamily::try_from(byte as u16)
     }
 }
-
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 /// Failure type for trying to decode a word into a processor family
 pub enum DecodingError {
     /// The word being parsed is invalid according to the spec
     /// and thus could no be decoded
-    #[fail(display = "Word does not exist in the processor family spec")]
     InvalidWord,
 }
+
+impl fmt::Display for DecodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodingError::InvalidWord => write!(f, "Word does not exist in the processor family spec"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodingError {}
 
 impl From<DecodingError> for MalformedStructureError {
     fn from(_: DecodingError) -> Self {


### PR DESCRIPTION
Make this crate compile in `no_std` environment.

- Remove `aho-corasick`
- Change `failure` to `std::error::Error`
- Introduce opt-out `std` feature

Closes #32 
