### PR TITLE
fix: replace homepage cargo field with repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "dmidecode"
 version = "0.8.0"
 description = "Decode SMBIOS/DMI information into accessible data structures"
 documentation = "https://docs.rs/dmidecode/"
-homepage = "https://github.com/jcreekmore/dmidecode.git"
+repository = "https://github.com/jcreekmore/dmidecode"
 license = "MIT"
 rust-version = "1.62"
 


### PR DESCRIPTION
Hi! While scraping crates.io I've found this crate to be using the `homepage` attribute instead of the `repository` attribute to link to the git repository. This wouldn't normally be a problem, but as explained in the docs [^1] the `homepage` field is made for linking to websites, while the `repository` field is for linking to git repositories. This change mainly helps automated tools disambiguate the links it finds inside Cargo.toml.

[^1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field