### PR TITLE
Derive traits for EntryPoint and EntryPointFormat

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,13 @@ pub mod bitfield;
 pub mod structures;
 pub use structures::*;
 
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 enum EntryPointFormat {
     V2,
     V3,
 }
 
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum EntryPoint {
     V2(EntryPointV2),
     V3(EntryPointV3),


### PR DESCRIPTION
Adds `#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]` to `EntryPoint` and `EntryPointFormat`. 