### PR TITLE
Add ARM64_SOC_ID in ProcessorCharacteristics

### DIFF
--- a/src/structures/004_processor.rs
+++ b/src/structures/004_processor.rs
@@ -66,6 +66,7 @@ bitflags! {
         const EXECUTE_PROTECTION = 0b0010_0000;
         const ENHANCED_VIRTUALIZATION = 0b0100_0000;
         const POWER_PERFORMANCE_CONTROL = 0b1000_0000;
+        const ARM64_SOC_ID = 0b0000_0010_0000_0000;
     }
 }
 


### PR DESCRIPTION
The Bit 9 in "Processor Characteristics" is "Arm64 SoC ID" [defined by SMBIOS specification](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.7.1.pdf).

> Arm64 SoC ID indicates that the processor supports returning a SoC ID value using the SMCCC_ARCH_SOC_ID architectural call, as defined in the Arm SMC Calling Convention Specification v1.2 at https://developer.arm.com/architectures/system-architectures/software-standards/smccc.

We need to expose this flag from struct ProcessorCharacteristics and then we can parse the cpuid in different ways as same as [the dmidecode CLI code](https://github.com/mirror/dmidecode/blob/master/dmidecode.c#L1079-L1089).