### PR TITLE
Do not error if processor family is 0x00

### DIFF
--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -138,7 +138,7 @@ macro_rules! layout {
     };
 }
 
-impl<'a> fmt::Display for Flag<'a> {
+impl fmt::Display for Flag<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.type_ {
             FlagType::Significant(meaning, description) => {
@@ -157,7 +157,7 @@ impl<'a> fmt::Display for Flag<'a> {
         }
     }
 }
-impl<'a> fmt::Debug for Flag<'a> {
+impl fmt::Debug for Flag<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Flag")
             .field("position", &self.position)
@@ -166,7 +166,7 @@ impl<'a> fmt::Debug for Flag<'a> {
     }
 }
 
-impl<'a> Default for FlagType<'a> {
+impl Default for FlagType<'_> {
     fn default() -> Self {
         Self::Unknown
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,12 +314,6 @@ impl From<(usize, usize)> for SmbiosVersion {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-struct SmbiosBound {
-    len: u16,
-    count: u16,
-}
-
 /// Failure type for trying to find the SMBIOS `EntryPoint` structure in memory.
 #[derive(Debug)]
 pub enum InvalidEntryPointError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,8 +420,6 @@ pub enum MalformedStructureError {
     /// The SMBIOS structure formatted section length does not correspond to SMBIOS reference
     /// specification
     InvalidFormattedSectionLength(InfoType, u16, &'static str, u8),
-    /// The SMBIOS structure contains an invalid processor family
-    InvalidProcessorFamily,
 }
 
 impl fmt::Display for MalformedStructureError {
@@ -453,9 +451,6 @@ impl fmt::Display for MalformedStructureError {
                     "Formatted section length of structure {:?} with handle {} should be {}{} bytes",
                     info_type, handle, spec, length
                 )
-            }
-            MalformedStructureError::InvalidProcessorFamily => {
-                write!(f, "Invalid processor family")
             }
         }
     }

--- a/src/structures/000_bios.rs
+++ b/src/structures/000_bios.rs
@@ -207,7 +207,7 @@ impl<'buffer> Bios<'buffer> {
     }
 }
 
-impl<'a> BitField<'a> for Characteristics {
+impl BitField<'_> for Characteristics {
     type Size = u64;
     fn value(&self) -> Self::Size {
         self.0
@@ -268,7 +268,7 @@ impl<'a> BitField<'a> for Characteristics {
     );
 }
 
-impl<'a> BitField<'a> for CharacteristicsExtension1 {
+impl BitField<'_> for CharacteristicsExtension1 {
     type Size = u8;
     fn value(&self) -> Self::Size {
         self.0
@@ -288,7 +288,7 @@ impl<'a> BitField<'a> for CharacteristicsExtension1 {
     );
 }
 
-impl<'a> BitField<'a> for CharacteristicsExtension2 {
+impl BitField<'_> for CharacteristicsExtension2 {
     type Size = u8;
     fn value(&self) -> Self::Size {
         self.0

--- a/src/structures/003_enclosure.rs
+++ b/src/structures/003_enclosure.rs
@@ -436,22 +436,22 @@ impl<'buffer> ContainedElements<'buffer> {
     }
 }
 
-impl<'buffer> PartialEq for ContainedElements<'buffer> {
+impl PartialEq for ContainedElements<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.chunks.clone().eq(other.chunks.clone())
             && self.count == other.count
             && self.record_length == other.record_length
     }
 }
-impl<'buffer> Eq for ContainedElements<'buffer> {}
-impl<'buffer> Hash for ContainedElements<'buffer> {
+impl Eq for ContainedElements<'_> {}
+impl Hash for ContainedElements<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.chunks.clone().for_each(|c| c.hash(state));
         self.count.hash(state);
         self.record_length.hash(state);
     }
 }
-impl<'buffer> Iterator for ContainedElements<'buffer> {
+impl Iterator for ContainedElements<'_> {
     type Item = ContainedElement;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/structures/004_processor.rs
+++ b/src/structures/004_processor.rs
@@ -1647,8 +1647,6 @@ impl fmt::Display for ProcessorUpgrade {
 
 #[cfg(test)]
 mod tests {
-    use core::convert::TryInto;
-
     use super::*;
     use crate::InfoType;
 
@@ -1703,7 +1701,7 @@ mod tests {
                 ),
                 _ => continue,
             };
-            assert_eq!(e, i.try_into().unwrap(), "{:#x}", i);
+            assert_eq!(e, i.into(), "{:#x}", i);
             assert_eq!(s, format!("{}", e));
         }
     }

--- a/src/structures/009_system_slots.rs
+++ b/src/structures/009_system_slots.rs
@@ -733,7 +733,7 @@ impl fmt::Display for SlotLength {
     }
 }
 
-impl<'a> BitField<'a> for SlotCharacteristics1 {
+impl BitField<'_> for SlotCharacteristics1 {
     type Size = u8;
     fn value(&self) -> Self::Size {
         self.0
@@ -763,7 +763,7 @@ impl From<u8> for SlotCharacteristics1 {
     }
 }
 
-impl<'a> BitField<'a> for SlotCharacteristics2 {
+impl BitField<'_> for SlotCharacteristics2 {
     type Size = u8;
     fn value(&self) -> Self::Size {
         self.0
@@ -848,18 +848,18 @@ impl<'a> From<&'a [u8]> for PeerDevices<'a> {
         Self(data.chunks(5))
     }
 }
-impl<'a> PartialEq for PeerDevices<'a> {
+impl PartialEq for PeerDevices<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.clone().eq(other.0.clone())
     }
 }
-impl<'buffer> Eq for PeerDevices<'buffer> {}
-impl<'buffer> Hash for PeerDevices<'buffer> {
+impl Eq for PeerDevices<'_> {}
+impl Hash for PeerDevices<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.clone().for_each(|c| c.hash(state));
     }
 }
-impl<'buffer> Iterator for PeerDevices<'buffer> {
+impl Iterator for PeerDevices<'_> {
     type Item = Device;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/structures/009_system_slots.rs
+++ b/src/structures/009_system_slots.rs
@@ -390,11 +390,11 @@ impl<'a> SystemSlots<'a> {
                         .map(Into::into),
                     data_bus_width: structure.get::<u8>(0x11).ok(),
                     peer_devices: structure.get_slice(0x13, 5 * n).map(Into::into),
-                    /// According to (SMBIOS Reference Specification
-                    /// 3.4)[https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf]
-                    /// fields below starts from offset 14h + 5*n, that looks like mistake.
-                    /// It shoud start from 13h + 5*n, because *Peer (S/B/D/F/Width)
-                    /// groups* field may has zero length
+                    // According to (SMBIOS Reference Specification
+                    // 3.4)[https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf]
+                    // fields below starts from offset 14h + 5*n, that looks like mistake.
+                    // It shoud start from 13h + 5*n, because *Peer (S/B/D/F/Width)
+                    // groups* field may has zero length
                     slot_information: structure.get::<u8>(0x14 + 5 * n).ok(),
                     slot_physical_width: structure.get::<u8>(0x15 + 5 * n).ok().map(Into::into),
                     slot_pitch: structure.get::<u16>(0x16 + 5 * n).ok().map(Into::into),
@@ -844,7 +844,7 @@ impl From<DeviceAndFunctionNumber> for u8 {
 }
 
 impl<'a> From<&'a [u8]> for PeerDevices<'a> {
-    fn from(data: &'a [u8]) -> PeerDevices {
+    fn from(data: &'a [u8]) -> Self {
         Self(data.chunks(5))
     }
 }

--- a/src/structures/013_bios_language.rs
+++ b/src/structures/013_bios_language.rs
@@ -86,7 +86,7 @@ impl<'a> Iterator for InstallableLanguages<'a> {
     }
 }
 
-impl<'a> BitField<'a> for LanguageFlags {
+impl BitField<'_> for LanguageFlags {
     type Size = u8;
     fn value(&self) -> Self::Size {
         self.0

--- a/src/structures/014_group_associations.rs
+++ b/src/structures/014_group_associations.rs
@@ -63,7 +63,7 @@ impl<'a> GroupItems<'a> {
         Self { data, index: 0 }
     }
 }
-impl<'a> Iterator for GroupItems<'a> {
+impl Iterator for GroupItems<'_> {
     type Item = GroupItem;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/structures/015_system_event_log/log_record_format.rs
+++ b/src/structures/015_system_event_log/log_record_format.rs
@@ -412,7 +412,7 @@ impl fmt::Display for VariableDataFormatType {
     }
 }
 
-impl<'a> BitField<'a> for PostResults {
+impl BitField<'_> for PostResults {
     type Size = u64;
     fn value(&self) -> Self::Size {
         self.0

--- a/src/structures/015_system_event_log/mod.rs
+++ b/src/structures/015_system_event_log/mod.rs
@@ -319,7 +319,7 @@ impl fmt::Display for AccessMethod {
     }
 }
 
-impl<'a> BitField<'a> for LogStatus {
+impl BitField<'_> for LogStatus {
     type Size = u8;
     fn value(&self) -> Self::Size {
         self.0
@@ -365,18 +365,18 @@ impl<'a> SupportedEventLogTypeDescriptors<'a> {
         Self(data.chunks(size))
     }
 }
-impl<'a> PartialEq for SupportedEventLogTypeDescriptors<'a> {
+impl PartialEq for SupportedEventLogTypeDescriptors<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.0.clone().eq(other.0.clone())
     }
 }
-impl<'a> Eq for SupportedEventLogTypeDescriptors<'a> {}
-impl<'a> Hash for SupportedEventLogTypeDescriptors<'a> {
+impl Eq for SupportedEventLogTypeDescriptors<'_> {}
+impl Hash for SupportedEventLogTypeDescriptors<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.clone().for_each(|c| c.hash(state));
     }
 }
-impl<'a> Iterator for SupportedEventLogTypeDescriptors<'a> {
+impl Iterator for SupportedEventLogTypeDescriptors<'_> {
     type Item = EventLogTypeDescriptor;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/structures/022_portable_battery.rs
+++ b/src/structures/022_portable_battery.rs
@@ -149,7 +149,7 @@ impl<'a> ManufactureDate<'a> {
         }
     }
 }
-impl<'a> fmt::Display for ManufactureDate<'a> {
+impl fmt::Display for ManufactureDate<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::None => Ok(()),
@@ -172,7 +172,7 @@ impl<'a> SerialNumber<'a> {
         }
     }
 }
-impl<'a> fmt::Display for SerialNumber<'a> {
+impl fmt::Display for SerialNumber<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::None => Ok(()),
@@ -203,7 +203,7 @@ impl<'a> DeviceChemistry<'a> {
         }
     }
 }
-impl<'a> fmt::Display for DeviceChemistry<'a> {
+impl fmt::Display for DeviceChemistry<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Other => write!(f, "Other"),


### PR DESCRIPTION
Currently, if the processor family is 0x00, the parsing of the SMBIOS structures fails since it is not in spec. While this is strictly correct, unfortunately there are occurrences in the wild of SMBIOS not being fully in-spec. Since this error isn't fatal (we can still parse other fields and other structs), allow this field and instead have a new `OutOfSpec` variant for the processor family enum. 

This is technically a breaking change since I removed an error variant, and added a new processor family variant but I think that's OK since this crate isn't v1.x. 

The test includes real world structure data from an Amazon EC2 node. 

The first commit is the interesting one, the rest are code cleanup that the compiler + clippy were warning about. 