### PR TITLE
handle uuid decode for smbios 2.6+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.62"
 
 [dependencies]
 bitflags = "1.2"
+uuid = "1.17.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6"


### PR DESCRIPTION
Fix #48 

Looking at `dmidecode` utility apparently as of version 2.6 of the SMBIOS specification, the first 3 fields of the UUID are supposed to be encoded on little-endian. The `dmidecode` utility does not swap bytes for smbios < 2.6 and I think we should be consistent with it.

I think this is a very obscure thing and we should completely hide this complexity to the users of the library returning an already parsed `Uuid` type in the specific format. This will avoid any doubt to anyone including smbios gurus. 

Regarding the implementation I created a private transparent new type wrapper to use instead of plain `[u8; 16]`. And then  the wrapper decodes the uuid field using the smbios version.
It leverage the type system to safely handle the conversion even for potential new smbios revisions with other fields and the compiler inlines the specific implementation in the top level branch skipping the second version compare.
This is the best solution I had to avoid any future errors and with zero cost abstraction.  