### PR TITLE
Add readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Decode SMBIOS/DMI information into accessible data structures"
 documentation = "https://docs.rs/dmidecode/"
 repository = "https://github.com/jcreekmore/dmidecode"
 license = "MIT"
-rust-version = "1.62"
+rust-version = "1.69"
 
 [dependencies]
 bitflags = "1.2"
@@ -16,5 +16,5 @@ pretty_assertions = "0.6"
 lazy_static = "1.4"
 
 [features]
-default = []
+default = ["std"]
 std = []

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# dmidecode
+
+[<img alt="github" src="https://img.shields.io/badge/github-jcreekmore/dmidecode-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/jcreekmore/dmidecode)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/dmidecode.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/dmidecode)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-dmidecode-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/dmidecode)
+[<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/jcreekmore/dmidecode/ci.yml?branch=master&style=for-the-badge" height="20">](https://github.com/jcreekmore/dmidecode/actions?query=branch%3Amaster)
+
+A Rust library for parsing raw **SMBIOS/DMI tables**. This crate lets you read and decode system firmware information provided via `/sys/firmware/dmi/tables/` on Linux, or directly from memory dumps.
+
+```toml
+# Cargo.toml
+[dependencies]
+dmidecode = "0.9"
+```
+
+## Example
+
+```rust
+use dmidecode::Structure;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    eprintln!("Collecting DMI Information...");
+
+    // Get the SMBIOS header and DMI table from sysfs.
+    let buf = std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point")?;
+    let dmi = std::fs::read("/sys/firmware/dmi/tables/DMI")?;
+    let entry = dmidecode::EntryPoint::search(&buf)?;
+
+    for table in entry.structures(&dmi) {
+        let Ok(table) = table else {
+            eprintln!("DMI tables contain malformed structure: {table:?}");
+            continue;
+        };
+
+        match table {
+            Structure::System(system) => {
+                // do stuff
+            }
+            Structure::BaseBoard(base_board) => {
+                // do stuff
+            }
+            // ...
+            _ => continue,
+        }
+    }
+
+    Ok(())
+}
+```
+
+
+## No-std support
+
+In no_std mode, almost all of the same API is available and works the same way.
+To depend on `dmidecode` in `no_std` mode, disable our default enabled "std" feature in
+`Cargo.toml`.
+
+```toml
+[dependencies]
+dmidecode = { version = "0.9", default-features = false }
+```
+
+## Rust Version Support
+The minimum supported Rust version is documented in the Cargo.toml file. This may be bumped in minor releases as necessary.
+
+## License
+
+`dmidecode` is released under the terms of the [MIT](./LICENSE) license.


### PR DESCRIPTION
When I first tried to use this library, I found it difficult to get started due to the lack of examples or documentation. This PR adds a `README.md` to help new users understand how to use the crate

## other changes
- bumped the `rust-version` in `Cargo.toml` to `1.69`, matching the version used in CI.
- Made the `std` feature enabled by default, as it is common practice for libraries to primarily target `std` environments.